### PR TITLE
Added support for converting security descriptors to SDDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ $ wconv uac --mapping
 
 ----
 
-The *DESC module* supports operations to convert *SecurityDescriptors* into human readable form.
+The *DESC module* supports operations to convert *SecurityDescriptors* into human readable form or SDDL format.
 
 ```console
 $ wconv desc -h
@@ -625,6 +625,7 @@ positional arguments:
 options:
   -h, --help   show this help message and exit
   --hex        specify the descriptor in hex format instead
+  --to-sddl    convert the descriptor to SDDL format
   --type type  permission type (default: ad)
   --sid sid    filter for a specific sid
   --adminsd    filter out inherited ACEs
@@ -721,7 +722,14 @@ $ wconv desc AQAEjKQgAADAIAAAAAAAA... --adminsd
 [+] 		+ DS_READ_PROP
 [+] 		+ DS_WRITE_PROP
 ```
+##### Convert SecurityDescriptor to SDDL
 
+Converts the parsed SecurityDescriptor into SDDL format.
+
+```console
+$ wconv desc --hex '0100049c20...' --to-sddl --type ad
+O:S-1-5-21-858338346-3861030516-3975240472-519D:(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;DA)(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;DC)(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;EA)(A;;SDRCWDWOCCDCLCSWRPWPDTLO;;;DA)(A;;SDRCWDWOCCDCLCSWRPWPDTLO;;;EA)(A;;RCLCRPLO;;;AU)
+```
 
 ### Library Information
 

--- a/tests/test_securitydescriptor.py
+++ b/tests/test_securitydescriptor.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import pytest
+import wconv.securitydescriptor as sd 
+
+# Define the format for your test parameters
+sd_to_sddl_format = 'hex_string, expected_sddl'
+
+# Define a list of tests
+sd_to_sddl_tests = [
+    # Test 1: Simple DACL (O:SID G:SID D:(A;;...))
+    (
+        '0100049c2001000000000000000000001400000004000c010600000005003800300100000100000068c9100efb78d21190d400c04f79dc550105000000000005150000002a34293374a622e6185bf1ec0002000005003800300100000100000068c9100efb78d21190d400c04f79dc550105000000000005150000002a34293374a622e6185bf1ec0302000005003800300100000100000068c9100efb78d21190d400c04f79dc550105000000000005150000002a34293374a622e6185bf1ec0702000000002400ff000f000105000000000005150000002a34293374a622e6185bf1ec0002000000002400ff000f000105000000000005150000002a34293374a622e6185bf1ec07020000000014009400020001010000000000050b0000000105000000000005150000002a34293374a622e6185bf1ec07020000',
+        'O:S-1-5-21-858338346-3861030516-3975240472-519D:(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;DA)(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;DC)(OA;;RPWPCR;0e10c968-78fb-11d2-90d4-00c04f79dc55;;EA)(A;;SDRCWDWOCCDCLCSWRPWPDTLO;;;DA)(A;;SDRCWDWOCCDCLCSWRPWPDTLO;;;EA)(A;;RCLCRPLO;;;AU)'
+    )
+]
+
+@pytest.mark.parametrize(sd_to_sddl_format, sd_to_sddl_tests)
+def test_security_descriptor_to_sddl(hex_string, expected_sddl):
+    """
+    Tests the end-to-end conversion from a raw hex security descriptor 
+    to its full SDDL string representation.
+    """ 
+    sd_object = sd.SecurityDescriptor.from_hex(hex_string)
+    sddl_output = sd_object.to_sddl()
+    assert sddl_output == expected_sddl

--- a/wconv/acl.py
+++ b/wconv/acl.py
@@ -45,3 +45,24 @@ class Acl:
             pos += ace_length
 
         return Acl(revision, ace_count, ace_list)
+
+    def to_sddl(self, acl_type: str = 'D', perm_type: str = 'file') -> str:
+        '''
+        Converts the Acl object (a collection of ACEs) into its SDDL string representation.
+
+        Parameters:
+            acl_type  The type tag for the ACL (D for DACL, S for SACL). Defaults to 'D'.
+            perm_type The object type the descriptor applies to (passed to Ace.to_sddl).
+
+        Returns:
+            ACL string in SDDL format (e.g., "D:(A;;...)(A;;...)")
+        '''
+        ace_sddl_strings = []
+        for ace in self.aces:
+            ace_sddl_strings.append(ace.to_sddl(perm_type=perm_type))
+
+        aces_sddl = "".join(ace_sddl_strings)
+
+        acl_sddl = f'{acl_type}:{aces_sddl}'
+
+        return acl_sddl

--- a/wconv/main.py
+++ b/wconv/main.py
@@ -68,6 +68,7 @@ parser_uac.add_argument('--toggle', metavar='flag', action='append', default=[],
 parser_desc = subparsers.add_parser('desc', help='convert security descriptor')
 parser_desc.add_argument('desc', metavar='b64', help='security descriptor in base64')
 parser_desc.add_argument('--hex', action='store_true', help='specify the descriptor in hex format instead')
+parser_desc.add_argument('--to-sddl', action='store_true', dest='to_sddl', help='convert the descriptor to SDDL format')
 parser_desc.add_argument('--type', metavar='type', choices=typelist, default='ad', help='permission type (default: ad)')
 parser_desc.add_argument('--sid', metavar='sid', help='filter for a specific sid')
 parser_desc.add_argument('--adminsd', action='store_true', help='filter out inherited ACEs')
@@ -238,20 +239,23 @@ def main():
             else:
                 desc = wconv.securitydescriptor.SecurityDescriptor.from_base64(args.desc, args.type)
 
-            if args.sid:
+            if not args.to_sddl:
+                if args.sid:
 
-                for ace in desc.filter_sid(args.sid):
-                    ace.pretty_print()
-                    print_blue('[+]')
+                    for ace in desc.filter_sid(args.sid):
+                        ace.pretty_print()
+                        print_blue('[+]')
 
-            if args.adminsd:
+                if args.adminsd:
 
-                for ace in desc.filter_inherited():
-                    ace.pretty_print()
-                    print_blue('[+]')
+                    for ace in desc.filter_inherited():
+                        ace.pretty_print()
+                        print_blue('[+]')
 
+                else:
+                    desc.pretty_print()
             else:
-                desc.pretty_print()
+                print(desc.to_sddl(perm_type=args.type))
 
         ##########################################################################
         #######                     No Command Selected                     ######
@@ -262,3 +266,6 @@ def main():
     except wconv.WConvException as e:
         print("[-] Error: " + str(e))
         sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/wconv/securitydescriptor.py
+++ b/wconv/securitydescriptor.py
@@ -37,10 +37,12 @@ class SecurityDescriptor:
             None
         '''
         print_blue(f'[+]{indent}Owner:\t', end='')
-        self.owner.pretty_print()
+        if self.owner:
+            self.owner.pretty_print()
 
         print_blue(f'[+]{indent}Group:\t', end='')
-        self.group.pretty_print()
+        if self.group:
+            self.group.pretty_print()
 
         print_blue(f'[+]{indent}Ace Count:\t', end='')
         print_yellow(self.dacl.ace_count)
@@ -142,3 +144,36 @@ class SecurityDescriptor:
             dacl = Acl.from_bytes(byte_data[dacl_offset:], perm_type)
 
         return SecurityDescriptor(owner_sid, group_sid, sacl, dacl)
+
+    def print_aces(self) -> None:
+        '''
+        Prints the formatted security descriptor ACEs only. 
+        '''
+        for ace in self.dacl.aces:
+            print(ace.to_sddl())
+    
+    def to_sddl(self, perm_type: str = 'file') -> str:
+        '''
+        Converts the SecurityDescriptor to SDDL format.
+
+        Parameters:
+            perm_type       Object type the descriptor applies to (file, service, ...)
+
+        Returns:
+            SDDL string
+        '''
+        sddl_parts = []
+
+        # Owner
+        if self.owner:
+            sddl_parts.append(f'O:{self.owner}')
+
+        # Group
+        if self.group:
+            sddl_parts.append(f'G:{self.group}')
+
+        # DACL
+        if self.dacl:
+            sddl_parts.append(f'{self.dacl.to_sddl(perm_type=perm_type)}')
+
+        return ''.join(sddl_parts)

--- a/wconv/sid.py
+++ b/wconv/sid.py
@@ -46,7 +46,7 @@ WELL_KNOWN_SIDS = {
     "S-1-5-21-[-0-9]+-500": "ADMINISTRATOR",
     "S-1-5-21-[-0-9]+-501": "GUEST",
     "S-1-5-21-[-0-9]+-502": "KRBTGT",
-    "S-1-5-21-[-0-9]+-512": "DOMAIN_ADMINS",
+    "S-1-5-21-[-0-9]+-512": "DOMAIN_ADMINS",   
     "S-1-5-21-[-0-9]+-513": "DOMAIN_USERS",
     "S-1-5-21-[-0-9]+-514": "DOMAIN_GUESTS",
     "S-1-5-21-[-0-9]+-515": "DOMAIN_COMPUTERS",
@@ -189,7 +189,7 @@ class SecurityIdentifier:
         dash_count = self.binary[1]
         return dash_count * 4 + 8
 
-    def get_well_known(sid_string: str) -> str:
+    def get_well_known(self) -> str:
         '''
         Get the well known name for the specified SID string. Notice that the
         WELL_KNOWN_SIDS dictionary contains regex like expression. A simple
@@ -203,7 +203,7 @@ class SecurityIdentifier:
         '''
         for key, value in WELL_KNOWN_SIDS.items():
 
-            if re.match(f'^{key}$', sid_string):
+            if re.match(f'^{key}$', str(self)):
                 return value
 
         return None
@@ -260,6 +260,7 @@ class SecurityIdentifier:
             result += '-'
 
         return result[0:-1]
+
 
     def to_b64(self) -> str:
         '''


### PR DESCRIPTION
please let me know if there is anything else you need.

Added the `.to_sddl()` functions to ACE, ACL, and SecurityDescriptor types.

Usage is in README.md